### PR TITLE
Deprecate the Syslog service from Pallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ in which case an HTTP proxy service SHOULD be provided.
 Environment variables: `SYSLOG_SERVER`, `SYSLOG_HOST`, `SYSLOG_PROTO`: host,
 port and protocol (`tcp` or `udp`) to connect to a Syslog instance.
 
-The application SHOULD prefer logging events to the Syslog service rather than
-to the console.
+The application MAY send logging events to the Syslog service, but it SHOULD prefer
+logging events to the console (`STDOUT`/`STDERR` as appropriate)
 
 ### Storage
 


### PR DESCRIPTION
As mentioned at the Kubernetes meeting on the 21st of May, we (Systems) are trying to fix up the logging mess at IX.

One of the things discussed was my intention to deprecate the Syslog interface that has been the preferred logging method from the beginning of the container platform at IX.

The reasons for doing this is are:
1.	To standardise our logging sources, so the source application is obvious and easily filterable
2.	To move in-line with the industry standard for container logging
3.	To maximise the choice of logging tools available to us
4.	To enable further debugging options not currently available to us
