### PR TITLE
Fix broken presentations

### DIFF
--- a/django-docker-presentation/index.html
+++ b/django-docker-presentation/index.html
@@ -14,7 +14,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-    <link rel="stylesheet" href="bower_components/reveal.js/css/reveal.min.css">
+    <link rel="stylesheet" href="bower_components/reveal.js/css/reveal.css">
     <link rel="stylesheet" href="./danni.css" id="theme">
 
     <!-- For syntax highlighting -->
@@ -50,7 +50,7 @@
     </div>
 
     <script src="bower_components/reveal.js/lib/js/head.min.js"></script>
-    <script src="bower_components/reveal.js/js/reveal.min.js"></script>
+    <script src="bower_components/reveal.js/js/reveal.js"></script>
     <script src="bower_components/jquery/dist/jquery.min.js"></script>
 
     <script>

--- a/pallet-forklift-presentation/diagrams/fresh-deploy.html
+++ b/pallet-forklift-presentation/diagrams/fresh-deploy.html
@@ -22,7 +22,8 @@
     </div>
 
     <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script src="../bower_components/coffee-script/extras/coffee-script.js"></script>
+    <script src="../bower_components/coffee-script/docs/v2/browser-compiler/coffeescript.js
+"></script>
     <script src="../vendor/jumly/jumly.min.js"></script>
   </body>
 </html>

--- a/pallet-forklift-presentation/diagrams/new-version.html
+++ b/pallet-forklift-presentation/diagrams/new-version.html
@@ -25,7 +25,7 @@
     </div>
 
     <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script src="../bower_components/coffee-script/extras/coffee-script.js"></script>
+    <script src="../bower_components/coffee-script/docs/v2/browser-compiler/coffeescript.js"></script>
     <script src="../vendor/jumly/jumly.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The paths for the compiled versions of the required coffeescript
and reveal.js libraries have changed. So this commit simply updates
those paths.